### PR TITLE
Add support for absolute imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
     "plugins": ["react"],
     "rules": {
         "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
-        "react/no-unescaped-entities": ["error", { "forbid": [">", "}"] }]
+        "react/no-unescaped-entities": ["error", { "forbid": [">", "}"] }],
+        "import/prefer-default-export": "off"
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,5 +19,12 @@
         "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
         "react/no-unescaped-entities": ["error", { "forbid": [">", "}"] }],
         "import/prefer-default-export": "off"
+    },
+    "settings": {
+        "import/resolver": {
+            "node": {
+                "paths": ["src"]
+            }
+        }
     }
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "baseUrl": "src"
+    },
+    "include": ["src"]
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import 'assets/styles.scss';
-import Header from 'components/Header';
+import { Header } from 'components';
 
 function App() {
     return (

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
-import './assets/styles.scss';
-import Header from './components/Header';
+import 'assets/styles.scss';
+import Header from 'components/Header';
 
 function App() {
     return (

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,4 +1,4 @@
-export default function Header() {
+export function Header() {
     return (
         <div className="header__container">
             <nav>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,1 @@
+export * from './Header';


### PR DESCRIPTION
### Changes
- Disabled ESLint rule forcing files with only export to always be default (conflicted with how I want to handle the component exports)
- Added `jsconfig.json` for configuring import statements to allow absolute imports by treating the `src` folder as the root folder.
- Changed all components to now import using absolute paths
- Added a `components/index.js` for handling exports of all components and allowing easy imports of any component using `import { Header, Hero, Footer } from 'components'`.